### PR TITLE
Fixing unexpected horizontal scroll bar

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -587,4 +587,6 @@ table.dataTable.dtr-inline.collapsed > tbody > tr[role="row"] > th:first-child:b
     }
 }
 
-
+div.dataTables_wrapper div.dataTables_filter input {
+    width: 80% !important;
+}


### PR DESCRIPTION
Fixing unexpected horizontal scroll bar on responsive tables with input included. Reducing the width of the input relative to the width of the container